### PR TITLE
Use newer ISO from ipxe for pxeboot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 NCOMPUTES ?= 2
+PXEBOOT_ISO=
 
 cluster:
 	@echo "Building a cluster with $(NCOMPUTES) compute nodes..."
 	@mkdir cluster
-	@./build-cluster.sh "$(NCOMPUTES)"
+	@./build-cluster.sh "$(NCOMPUTES)" "$(PXEBOOT_ISO)"
 
 clean:
 	@if [ -d cluster ]; then cd cluster; vagrant destroy -f; fi

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 NCOMPUTES ?= 2
 PXEBOOT_ISO := ipxe.iso
 
-$(PXEBOOT_ISO):
-    wget -O "$@" http://boot.ipxe.org/ipxe.iso
-    
-cluster: $(PXEBOOT_ISO)
+cluster:
+	@wget -O ${PXEBOOT_ISO} -c https://boot.ipxe.org/ipxe.iso
 	@echo "Building a cluster with $(NCOMPUTES) compute nodes..."
 	@mkdir cluster
 	@./build-cluster.sh "$(NCOMPUTES)" "$(PXEBOOT_ISO)"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 NCOMPUTES ?= 2
 PXEBOOT_ISO=
 
-cluster:
+$(PXEBOOT_ISO):
+    wget -O "$@" http://boot.ipxe.org/ipxe.iso
+    
+cluster: $(PXEBOOT_ISO)
 	@echo "Building a cluster with $(NCOMPUTES) compute nodes..."
 	@mkdir cluster
 	@./build-cluster.sh "$(NCOMPUTES)" "$(PXEBOOT_ISO)"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 NCOMPUTES ?= 2
 PXEBOOT_ISO := ipxe.iso
 
-$(PXEBOOT_ISO):
-    wget -O "$@" http://boot.ipxe.org/ipxe.iso
-    
 cluster: $(PXEBOOT_ISO)
 	@echo "Building a cluster with $(NCOMPUTES) compute nodes..."
 	@mkdir cluster
 	@./build-cluster.sh "$(NCOMPUTES)" "$(PXEBOOT_ISO)"
+
+$(PXEBOOT_ISO):
+	wget -O "$@" http://boot.ipxe.org/ipxe.iso
 
 clean:
 	@if [ -d cluster ]; then cd cluster; vagrant destroy -f; fi

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 NCOMPUTES ?= 2
 PXEBOOT_ISO := ipxe.iso
 
-cluster:
-	@wget -O ${PXEBOOT_ISO} -c https://boot.ipxe.org/ipxe.iso
+$(PXEBOOT_ISO):
+    wget -O "$@" http://boot.ipxe.org/ipxe.iso
+    
+cluster: $(PXEBOOT_ISO)
 	@echo "Building a cluster with $(NCOMPUTES) compute nodes..."
 	@mkdir cluster
 	@./build-cluster.sh "$(NCOMPUTES)" "$(PXEBOOT_ISO)"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NCOMPUTES ?= 2
-PXEBOOT_ISO=
+PXEBOOT_ISO := ipxe.iso
 
 $(PXEBOOT_ISO):
     wget -O "$@" http://boot.ipxe.org/ipxe.iso

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -6,6 +6,12 @@ if [ -z "$NCOMPUTES" ] || [ "$NCOMPUTES" -lt 1 ] || [ "$NCOMPUTES" -gt 10 ]; the
     exit 1
 fi
 
+PXEBOOT_ISO="$2"
+if [ ! -f "$PXEBOOT_ISO" ]; then
+    echo "You must supply a PXEBOOT ISO that exists."
+    exit 1
+fi
+
 COMPUTE_DEFS=""
 VAGRANT_DEFS=""
 for ((i=1;i<=NCOMPUTES;i++)); do

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -6,12 +6,6 @@ if [ -z "$NCOMPUTES" ] || [ "$NCOMPUTES" -lt 1 ] || [ "$NCOMPUTES" -gt 10 ]; the
     exit 1
 fi
 
-PXEBOOT_ISO="$2"
-if [ ! -f "$PXEBOOT_ISO" ]; then
-    echo "You need to point to a PXEBOOT ISO from https://ipxe.org/download"
-    exit 1
-fi
-
 COMPUTE_DEFS=""
 VAGRANT_DEFS=""
 for ((i=1;i<=NCOMPUTES;i++)); do

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -66,3 +66,5 @@ cp slurmdbd.sql cluster/slurmdbd.sql
 cp slurm-setup.sh cluster/slurm-setup.sh
 cp cgroup.conf cluster/cgroup.conf
 cp cgroup_allowed_devices_file.conf cluster/cgroup_allowed_devices_file.conf
+
+cp "$PXEBOOT_ISO" "cluster/$PXEBOOT_ISO"

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -6,6 +6,12 @@ if [ -z "$NCOMPUTES" ] || [ "$NCOMPUTES" -lt 1 ] || [ "$NCOMPUTES" -gt 10 ]; the
     exit 1
 fi
 
+PXEBOOT_ISO="$2"
+if [ ! -f "$PXEBOOT_ISO" ]; then
+    echo "You need to point to a PXEBOOT ISO from https://ipxe.org/download"
+    exit 1
+fi
+
 COMPUTE_DEFS=""
 VAGRANT_DEFS=""
 for ((i=1;i<=NCOMPUTES;i++)); do
@@ -26,11 +32,20 @@ EOF`
           'modifyvm', :id,
           '--nic1', 'intnet',
           '--intnet1', 'provisioning',
-          '--boot1', 'net',
+          '--boot1', 'dvd',
           '--boot2', 'none',
           '--boot3', 'none',
           '--boot4', 'none',
           '--macaddress1', '221a2b0000$((i-1))$((i-1))'
+        ]
+
+        vboxc$i.customize [
+          "storageattach", :id,
+          "--storagectl", "IDE",
+          "--port", "0",
+          "--device", "0",
+          "--type", "dvddrive",
+          "--medium", "${PXEBOOT_ISO}"
         ]
       end
       c$i.vm.boot_timeout = 10


### PR DESCRIPTION
Werewulf seems to require bzImage support for compute nodes
pxebooting. However, the default 'network boot' support in
VirtualBox does not seem to support that, nor does it intend
to (https://www.virtualbox.org/ticket/15159). This causes
compute nodes to not come up.

![image](https://user-images.githubusercontent.com/30430/80212313-e1175900-8654-11ea-90ef-3dd2db09618f.png)

Based on [this
comment](https://www.virtualbox.org/ticket/15159#comment:4)
I was able to get compute nodes to come up by using the upstream
IPXE pxeboot image. This is the 'full' version of what VirtualBox
uses, and supports bzImage.

This PR requires now that the user download and keep an ISO
handy. However, we could also do the download ourselves, and spare
the user this extra step.
